### PR TITLE
Lookup based u8 conversion

### DIFF
--- a/include/owrx/connector.hpp
+++ b/include/owrx/connector.hpp
@@ -65,7 +65,7 @@ namespace Owrx {
             double center_frequency;
             double sample_rate;
             double ppm;
-            uint8_t uint8Float[UINT8_MAX];
+            float uint8Float[UINT8_MAX];
             GainSpec* gain;
             Ringbuffer<float>* float_buffer;
             Ringbuffer<uint8_t>* uint8_buffer;

--- a/include/owrx/connector.hpp
+++ b/include/owrx/connector.hpp
@@ -65,6 +65,7 @@ namespace Owrx {
             double center_frequency;
             double sample_rate;
             double ppm;
+            uint8_t uint8Float[UINT8_MAX];
             GainSpec* gain;
             Ringbuffer<float>* float_buffer;
             Ringbuffer<uint8_t>* uint8_buffer;

--- a/src/lib/connector.cpp
+++ b/src/lib/connector.cpp
@@ -20,6 +20,10 @@ using namespace Owrx;
 
 Connector::Connector() {
     gain = new AutoGainSpec();
+    //initialize lookup table
+    for (uint8_t i = 0 ; i < UINT_MAX ; i++){
+        uint8Float[i] = ((float) i) / (UINT8_MAX / 2.0f) - 1.0f;
+    }
 }
 
 void Connector::init_buffers() {
@@ -358,7 +362,7 @@ OWRX_CONNECTOR_TARGET_CLONES
 void Connector::convert(uint8_t* __restrict__ input, float* __restrict__ output, uint32_t len) {
     uint32_t i;
     for (i = 0; i < len; i++) {
-        output[i] = ((float) (input[i])) / (UINT8_MAX / 2.0f) - 1.0f;
+        output[i] = uint8Float[input[i]];
     }
 }
 

--- a/src/lib/connector.cpp
+++ b/src/lib/connector.cpp
@@ -21,7 +21,7 @@ using namespace Owrx;
 Connector::Connector() {
     gain = new AutoGainSpec();
     //initialize lookup table
-    for (uint8_t i = 0 ; i < UINT_MAX ; i++){
+    for (uint8_t i = 0 ; i < UINT8_MAX ; i++){
         uint8Float[i] = ((float) i) / (UINT8_MAX / 2.0f) - 1.0f;
     }
 }


### PR DESCRIPTION
Hello Jakob,
this is a relatively trivial  pull request adding lookup table based u8->float conversion, that helped me to get openwebrx running  acceptably on an old "thin client" HP fanless PC.  This  creates an array of 256 floats that saves float mult/div operations when geeting data from rtl_sdr dongle. Please merge if you find it useful.  Note that it is my first first pull request on github so I hope I did not screw it up.   

Vy 73,

Piotr, SP9MUF

