### PR TITLE
Restarting stream if readStream() keeps timing out.

### DIFF
--- a/src/app/soapy_connector.hpp
+++ b/src/app/soapy_connector.hpp
@@ -9,6 +9,7 @@
 using namespace Owrx;
 
 #define SOAPY_BUFFER_SIZE 64512 * 4
+#define SOAPY_RESTART_SECS 60
 
 class SoapyConnector: public Connector {
     public:


### PR DESCRIPTION
These changes will make Soapy connector restart streaming if readStream() keeps timing out for a long while (currently set to 60 seconds). The main reason for this behavior appears to be USB-connected SDR hardware having rare, intermittent failures due to fluctuating power. If this happens, SoapySDR may need to activateStream() again.

PS: Also somewhat reduced the number of log messages on timeouts, but it will tell how long it timed out in the log now.